### PR TITLE
Menu Bar

### DIFF
--- a/src/app/NewClientForm/page.module.scss
+++ b/src/app/NewClientForm/page.module.scss
@@ -5,6 +5,7 @@
 
 .formParagraph {
   font-size: 24px;
+  width: 55vw;
 
   @media (max-width: 1022px) {
     padding: 0 12px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { About } from "@/components/About/About";
 import { SwiperPlans } from "../components/SwiperPlans/SwiperPlans";
 import { PlanContainer } from "@/components/PlanContainer/PlanContainer";
 import { Footer } from "@/components/Footer/Footer";
+import { IdListData } from "@/assets/data/IdListData";
 
 export default function Home() {
   return (
@@ -15,7 +16,7 @@ export default function Home() {
       <About />
       <ClientQuote />
       <Tagline />
-      <div id="FitnessPlans">
+      <div id={IdListData.FitnessPlans}>
         <div className={styles.desktop}>
           <PlanContainer />
         </div>

--- a/src/assets/data/IdListData.ts
+++ b/src/assets/data/IdListData.ts
@@ -1,0 +1,7 @@
+export enum IdListData {
+  Footer = "Footer",
+  FitnessPlans = "FitnessPlans",
+  About = "About",
+  Testimonials = "Testimonials",
+  Home = "Home",
+}

--- a/src/assets/data/MenuItemData.js
+++ b/src/assets/data/MenuItemData.js
@@ -1,7 +1,12 @@
 export const menuItemData = [
-  "Home",
-  "Client Quotes",
-  "Pricing and Plans",
-  "About",
-  "Contact",
+  { title: "Home", pathname: "/", path: "" },
+  { title: "Client Quotes", pathname: "", path: "/#Testimonials" },
+  { title: "Pricing and Plans", pathname: "", path: "" },
+  { title: "About", pathname: "", path: "" },
+  { title: "Contact", pathname: "", path: "" },
+  {
+    title: "New Client Form",
+    pathname: "/NewClientForm",
+    path: "NewClientForm",
+  },
 ];

--- a/src/assets/data/MenuItemData.js
+++ b/src/assets/data/MenuItemData.js
@@ -1,9 +1,11 @@
+import { IdListData } from "./IdListData";
+
 export const menuItemData = [
   { title: "Home", path: "/" },
-  { title: "Client Quotes", path: "/#Testimonials" },
-  { title: "Pricing and Plans", path: "/#FitnessPlans" },
-  { title: "About", path: "/#About" },
-  { title: "Contact", path: "/#Footer" },
+  { title: "Client Quotes", path: `/#${IdListData.Testimonials}` },
+  { title: "Pricing and Plans", path: `/#${IdListData.FitnessPlans}` },
+  { title: "About", path: `/#${IdListData.About}` },
+  { title: "Contact", path: `/#${IdListData.Footer}` },
   {
     title: "New Client Form",
     path: "/NewClientForm",

--- a/src/assets/data/MenuItemData.js
+++ b/src/assets/data/MenuItemData.js
@@ -1,12 +1,11 @@
 export const menuItemData = [
-  { title: "Home", pathname: "/", path: "" },
-  { title: "Client Quotes", pathname: "", path: "/#Testimonials" },
-  { title: "Pricing and Plans", pathname: "", path: "" },
-  { title: "About", pathname: "", path: "" },
-  { title: "Contact", pathname: "", path: "" },
+  { title: "Home", path: "/" },
+  { title: "Client Quotes", path: "/#Testimonials" },
+  { title: "Pricing and Plans", path: "/#FitnessPlans" },
+  { title: "About", path: "/#About" },
+  { title: "Contact", path: "/#Footer" },
   {
     title: "New Client Form",
-    pathname: "/NewClientForm",
-    path: "NewClientForm",
+    path: "/NewClientForm",
   },
 ];

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -9,10 +9,11 @@ import {
   ABOUT_BIO,
   QUALIFICATIONS_DATA,
 } from "../../assets/data/QualificationsData";
+import { IdListData } from "@/assets/data/IdListData";
 
 export function About() {
   return (
-    <div className={styles.aboutMain} id="About">
+    <div className={styles.aboutMain} id={IdListData.About}>
       <div className={styles.imageMain}>
         <div className={styles.imageLayout}>
           <Image

--- a/src/components/ClientForm/ClientForm.tsx
+++ b/src/components/ClientForm/ClientForm.tsx
@@ -115,11 +115,10 @@ export function ClientForm() {
       })}
 
       <div
-        className={classNames(
-          dropDownOptions.injuries === Injuries.Yes
-            ? styles.textAreaContainer
-            : styles.hide
-        )}
+        className={classNames({
+          [styles.textAreaContainer]: dropDownOptions.injuries === Injuries.Yes,
+          [styles.hide]: dropDownOptions.injuries === Injuries.No,
+        })}
       >
         <label htmlFor="yesInjuries">Please describe your injury</label>
         <textarea

--- a/src/components/ClientQuote/ClientQuote.tsx
+++ b/src/components/ClientQuote/ClientQuote.tsx
@@ -3,10 +3,11 @@ import finishLine from "../../assets/images/finishLine.jpg";
 import Image from "next/legacy/image";
 import classNames from "classnames";
 import { SwiperQuotes } from "../SwiperQuotes/SwiperQuotes";
+import { IdListData } from "@/assets/data/IdListData";
 
 export function ClientQuote() {
   return (
-    <div className={styles.main} id="Testimonials">
+    <div className={styles.main} id={IdListData.Testimonials}>
       <SwiperQuotes />
 
       <div className={styles.imageWrapper}>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ import { FooterData } from "../../assets/data/FooterData";
 
 export function Footer() {
   return (
-    <main className={styles.main}>
+    <main className={styles.main} id="Footer">
       <div className={styles.left}>
         <Logo />
         <div className={styles.contactTypeContainer}>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,10 +3,11 @@ import { Logo } from "../Logo/Logo";
 import styles from "./Footer.module.scss";
 import { FaFacebook, FaInstagram } from "react-icons/fa";
 import { FooterData } from "../../assets/data/FooterData";
+import { IdListData } from "@/assets/data/IdListData";
 
 export function Footer() {
   return (
-    <main className={styles.main} id="Footer">
+    <main className={styles.main} id={IdListData.Footer}>
       <div className={styles.left}>
         <Logo />
         <div className={styles.contactTypeContainer}>

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -78,6 +78,10 @@
   }
 }
 
+.positionFixed {
+  position: fixed;
+}
+
 .headerScrolled {
   background-color: var(--black-font);
 }
@@ -101,7 +105,6 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 2vh;
   background-color: var(--black-font);
 }
 

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -106,11 +106,13 @@
 }
 
 .menuNav.showMenu {
-  width: 100%;
-  padding-left: 10vw;
+  width: 25%;
+  padding-left: 24px;
   position: fixed;
+
   @media (max-width: 1023px) {
     width: 100%;
+    padding-left: 10vw;
   }
 }
 .menuNav.hideNav {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -83,7 +83,6 @@ const Header = ({
                 key={`menuItem-${index}`}
                 closeMenu={closeMenu}
                 name={menuItem.title}
-                pathname={menuItem.pathname}
                 path={menuItem.path}
               />
             );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -36,12 +36,13 @@ const Header = ({
   const handleToggle = () => {
     if (navbarStatus === true) {
       changeNavbarStatus(false);
-      document.body.style.overflow = "unset";
+      // these help to not allow scrolling. Leaving until we decide if we want that
+      // document.body.style.overflow = "unset";
     } else {
       changeNavbarStatus(true);
-      if (typeof window != "undefined" && window.document) {
-        document.body.style.overflow = "hidden";
-      }
+      // if (typeof window != "undefined" && window.document) {
+      // document.body.style.overflow = "hidden";
+      // }
     }
   };
 
@@ -54,6 +55,7 @@ const Header = ({
     <div
       className={classNames(
         styles.header,
+        navbarStatus ? styles.positionFixed : "",
         color ? styles.headerScrolled : styles.none
       )}
     >
@@ -75,12 +77,14 @@ const Header = ({
             navbarStatus === true ? styles.showMenu : styles.hideNav
           )}
         >
-          {menuItemData.map((name, index) => {
+          {menuItemData.map((menuItem, index) => {
             return (
               <MenuItem
                 key={`menuItem-${index}`}
                 closeMenu={closeMenu}
-                name={name}
+                name={menuItem.title}
+                pathname={menuItem.pathname}
+                path={menuItem.path}
               />
             );
           })}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -19,10 +19,8 @@ const Header = ({
   backgroundColorSwitch = false,
   scrollValue = BACKGROUND_COLOR_SCROLL_HEIGHT,
 }: Props) => {
-  const navbarStatus = useNavbarStore((state) => state.navbarStatus);
-  const changeNavbarStatus = useNavbarStore(
-    (state) => state.changeNavbarStatus
-  );
+  const isNavbarOpen = useNavbarStore((state) => state.isNavbarOpen);
+  const setIsNavbarOpen = useNavbarStore((state) => state.setIsNavbarOpen);
   const checkRef = useRef<HTMLInputElement>(null);
   const [color, setColor] = useState<boolean>(backgroundColorSwitch);
   const changeColor = () => {
@@ -33,29 +31,16 @@ const Header = ({
     window.addEventListener("scroll", changeColor);
   }, []);
 
-  const handleToggle = () => {
-    if (navbarStatus === true) {
-      changeNavbarStatus(false);
-      // these help to not allow scrolling. Leaving until we decide if we want that
-      // document.body.style.overflow = "unset";
-    } else {
-      changeNavbarStatus(true);
-      // if (typeof window != "undefined" && window.document) {
-      // document.body.style.overflow = "hidden";
-      // }
-    }
-  };
-
   const closeMenu = () => {
     checkRef.current!.checked = false;
-    changeNavbarStatus(false);
+    setIsNavbarOpen(false);
   };
 
   return (
     <div
       className={classNames(
         styles.header,
-        navbarStatus ? styles.positionFixed : "",
+        isNavbarOpen ? styles.positionFixed : "",
         color ? styles.headerScrolled : styles.none
       )}
     >
@@ -65,7 +50,7 @@ const Header = ({
       <label className={styles.hamburgerMenu} htmlFor="hamburgerMenu">
         <input
           type="checkbox"
-          onClick={handleToggle}
+          onClick={() => setIsNavbarOpen(!isNavbarOpen)}
           ref={checkRef}
           id="hamburgerMenu"
         />
@@ -74,15 +59,15 @@ const Header = ({
         <ul
           className={classNames(
             styles.menuNav,
-            navbarStatus === true ? styles.showMenu : styles.hideNav
+            isNavbarOpen === true ? styles.showMenu : styles.hideNav
           )}
         >
           {menuItemData.map((menuItem, index) => {
             return (
               <MenuItem
-                key={`menuItem-${index}`}
+                key={index}
                 closeMenu={closeMenu}
-                name={menuItem.title}
+                title={menuItem.title}
                 path={menuItem.path}
               />
             );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -38,11 +38,11 @@ const Header = ({
 
   return (
     <div
-      className={classNames(
-        styles.header,
-        isNavbarOpen ? styles.positionFixed : "",
-        color ? styles.headerScrolled : styles.none
-      )}
+      className={classNames(styles.header, {
+        [styles.positionFixed]: isNavbarOpen,
+        [styles.headerScrolled]: color,
+        [styles.none]: !color,
+      })}
     >
       <Link href={"/"} className={styles.textDecorationNone}>
         <Logo />
@@ -57,10 +57,10 @@ const Header = ({
       </label>
       <div className={styles.sideNav}>
         <ul
-          className={classNames(
-            styles.menuNav,
-            isNavbarOpen === true ? styles.showMenu : styles.hideNav
-          )}
+          className={classNames(styles.menuNav, {
+            [styles.showMenu]: isNavbarOpen,
+            [styles.hideNav]: !isNavbarOpen,
+          })}
         >
           {menuItemData.map((menuItem, index) => {
             return (

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -4,12 +4,13 @@ import HeroMobile from "../../assets/images/MobileHerov1.jpg";
 import Image from "next/legacy/image";
 import styles from "./Hero.module.scss";
 import Header from "../Header/Header";
+import { IdListData } from "@/assets/data/IdListData";
 
 export function Hero() {
   const ICON_SIZE = "40px";
 
   return (
-    <main className={styles.main} id="Home">
+    <main className={styles.main} id={IdListData.Home}>
       <Header backgroundColorSwitch={false} scrollValue={200} />
       <div className={styles.imageWrapper}>
         <div className={`${styles.mobileImage} ${styles.image}`}>

--- a/src/components/MenuItem/MenuItem.module.scss
+++ b/src/components/MenuItem/MenuItem.module.scss
@@ -7,7 +7,7 @@
   color: var(--primary-font);
   font-weight: 500;
   font-size: 24px;
-  width: 20vw;
+  min-width: 15vw;
   @media (max-width: 1023px) {
     width: 70vw;
   }

--- a/src/components/MenuItem/MenuItem.module.scss
+++ b/src/components/MenuItem/MenuItem.module.scss
@@ -1,14 +1,12 @@
 .menuItem {
   font-size: 20px;
-  width: 30vw;
-  border-radius: 25px;
   display: flex;
   justify-content: flex-start;
   align-items: center;
   padding: 15px;
   color: var(--primary-font);
-  background-color: var(--gray-color);
-  font-weight: 400;
+  font-weight: 500;
+  font-size: 32px;
 
   @media (max-width: 1023px) {
     width: 70vw;
@@ -16,8 +14,6 @@
 }
 
 .menuItem:hover {
-  background-color: var(--background-main);
-  color: var(--black-font);
   transform: scale(1.1);
 }
 

--- a/src/components/MenuItem/MenuItem.module.scss
+++ b/src/components/MenuItem/MenuItem.module.scss
@@ -6,15 +6,23 @@
   padding: 15px;
   color: var(--primary-font);
   font-weight: 500;
-  font-size: 32px;
-
+  font-size: 24px;
+  width: 20vw;
   @media (max-width: 1023px) {
     width: 70vw;
   }
 }
 
-.menuItem:hover {
+.menuItem:hover,
+.currentPath:hover {
   transform: scale(1.1);
+}
+
+.currentPath {
+  color: var(--black-font);
+  border-radius: 56px;
+  background-color: var(--light-brown);
+  padding-right: 50px;
 }
 
 .link {

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -20,10 +20,9 @@ export function MenuItem({ closeMenu, title, path }: Props) {
       as={path}
     >
       <li
-        className={classNames(
-          styles.menuItem,
-          path === RouterPathName ? styles.currentPath : ""
-        )}
+        className={classNames(styles.menuItem, {
+          [styles.currentPath]: path === RouterPathName,
+        })}
         onClick={() => {
           closeMenu();
         }}

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -5,11 +5,11 @@ import { usePathname } from "next/navigation";
 
 type Props = {
   closeMenu: Function;
-  name: string;
+  title: string;
   path: string;
 };
 
-export function MenuItem({ closeMenu, name, path }: Props) {
+export function MenuItem({ closeMenu, title, path }: Props) {
   const RouterPathName = usePathname();
   return (
     <Link
@@ -28,7 +28,7 @@ export function MenuItem({ closeMenu, name, path }: Props) {
           closeMenu();
         }}
       >
-        {name}
+        {title}
       </li>
     </Link>
   );

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -18,7 +18,6 @@ export function MenuItem({ closeMenu, name, path }: Props) {
       }}
       className={styles.link}
       as={path}
-      // scroll={false}
     >
       <li
         className={classNames(

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -1,17 +1,32 @@
 import Link from "next/link";
 import styles from "./MenuItem.module.scss";
+import classNames from "classnames";
+import { usePathname } from "next/navigation";
 
 type Props = {
   closeMenu: Function;
-  name: String;
+  name: string;
+  pathname: string;
+  path: string;
 };
 
-export function MenuItem({ closeMenu, name }: Props) {
+export function MenuItem({ closeMenu, name, pathname, path }: Props) {
+  const pathName = usePathname();
   return (
-    <Link href={"/"} className={styles.link} as="/">
+    <Link
+      href={{
+        pathname: pathname,
+      }}
+      className={styles.link}
+      // scroll={false}
+    >
       <li
-        className={styles.menuItem}
+        className={classNames(
+          styles.menuItem,
+          pathname === pathName ? styles.currentPath : ""
+        )}
         onClick={() => {
+          console.log(path);
           closeMenu();
         }}
       >

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -6,27 +6,26 @@ import { usePathname } from "next/navigation";
 type Props = {
   closeMenu: Function;
   name: string;
-  pathname: string;
   path: string;
 };
 
-export function MenuItem({ closeMenu, name, pathname, path }: Props) {
-  const pathName = usePathname();
+export function MenuItem({ closeMenu, name, path }: Props) {
+  const RouterPathName = usePathname();
   return (
     <Link
       href={{
-        pathname: pathname,
+        pathname: path,
       }}
       className={styles.link}
+      as={path}
       // scroll={false}
     >
       <li
         className={classNames(
           styles.menuItem,
-          pathname === pathName ? styles.currentPath : ""
+          path === RouterPathName ? styles.currentPath : ""
         )}
         onClick={() => {
-          console.log(path);
           closeMenu();
         }}
       >

--- a/src/stores/navbarStore.js
+++ b/src/stores/navbarStore.js
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
 export const useNavbarStore = create((set) => ({
-  navbarStatus: false,
-  changeNavbarStatus: (status) => set((state) => ({ navbarStatus: status })),
+  isNavbarOpen: false,
+  setIsNavbarOpen: (status) => set((state) => ({ isNavbarOpen: status })),
 }));


### PR DESCRIPTION
Updated Menu Bar. Less width on Desktop. The only two pages are home and NewClientForm so those are the only ones that are highlighted. Otherwise I would need to use Intersection Observer to keep track of where I am. Let me know your thoughts. When you pull it down then you can play around with it. There are some interesting things with how it animates on desktop if the header isnt at the top of the screen. 

<img width="1280" alt="Screen Shot 2024-04-06 at 1 43 45 PM" src="https://github.com/khintz34/sampaushacoaching/assets/78268730/0fb743cc-8c3f-4fd7-a07a-4d23b4564acd">
<img width="1278" alt="Screen Shot 2024-04-06 at 1 43 54 PM" src="https://github.com/khintz34/sampaushacoaching/assets/78268730/2df10bd1-e568-4922-8660-0235ccb957eb">
<img width="1280" alt="Screen Shot 2024-04-06 at 1 44 05 PM" src="https://github.com/khintz34/sampaushacoaching/assets/78268730/783e65c6-54f9-4388-a9b5-1661b742d2d7">
<img width="233" alt="Screen Shot 2024-04-06 at 1 44 18 PM" src="https://github.com/khintz34/sampaushacoaching/assets/78268730/78b2fc08-e204-4b71-a275-b1a78ebe8242">
